### PR TITLE
improve portability of venv instuctions (viz tutorials)

### DIFF
--- a/tutorials/viz/README.md
+++ b/tutorials/viz/README.md
@@ -1,24 +1,31 @@
-# Data vizualisation with Python (yt and nonos)
+# Data vizualisation with Python (yt and nonos): pre-requisites
 
 These tutorials require Python 3.8 or newer.
 
 Both tutorials include requirement files. It is strongly advised to create virtual
 environments before installing anything specifically for these tutorials. To get
-started, navigate to a tutorial's subdirectory and create a virtual environment ...
+started, navigate to a tutorial's subdirectory
 
-## with conda
 ```shell
-$ conda config --add channels conda-forge
-$ conda create --name=<name> --file=requirements.txt python=3.10
+$ cd idefix-days/tutorials/viz/<dir>
+```
+(where `<dir>` is a placeholder)
+
+and create a virtual environment...
+
+... with conda (`<name>` is a placeholder)
+```shell
+$ conda create --name=<name> python=3.10
 $ conda activate <name>
 ```
 
-use a meaningful name each time (for instance `idefix-yt-tutorial`, `nonos-tutorial` ...)
-
-## or with `pip`
+... or with `venv`
 ```shell
 $ python -m venv .venv
 $ source .venv/bin/activate
-$ python -m pip install --upgrade pip
-$ python -m pip install --requirement requirements.txt
+```
+
+Then proceed to install requirements
+```shell
+$ python -m pip install -r requirements.txt
 ```


### PR DESCRIPTION
So we don't have to publish nonos and its dependencies on conda-forge